### PR TITLE
Add an SNS topic for CloudWatch alarms

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ future changes by simply running `terraform apply
 
 | Name | Source | Version |
 |------|--------|---------|
+| cw\_alarm\_sns | github.com/cisagov/cw-alarm-sns-tf-module | n/a |
 | provisionaccount | github.com/cisagov/provisionaccount-role-tf-module | n/a |
 
 ## Resources ##
@@ -103,6 +104,7 @@ future changes by simply running `terraform apply
 
 | Name | Description |
 |------|-------------|
+| cw\_alarm\_sns\_topic | The SNS topic to which a message is sent when a CloudWatch alarm is triggered. |
 | provisionaccount\_role | The IAM role that allows sufficient permissions to provision all AWS resources in the PCA account. |
 
 ## Notes ##

--- a/README.md
+++ b/README.md
@@ -42,11 +42,16 @@ To do this bootstrapping, follow these steps:
 
 1. Create a Terraform workspace (if you haven't already done so) by running
    `terraform workspace new <workspace_name>`
-1. Create a `<workspace_name>.tfvars` file with all of the required
-   variables (see [Inputs](#Inputs) below for details):
+1. Create a `<workspace_name>.tfvars` file with any optional variables
+   that you wish to override (see [Inputs](#Inputs) below for
+   details):
 
-   ```console
-   users_account_id = "222222222222"
+   ```hcl
+   tags = {
+     Team        = "VM Fusion - Development"
+     Application = "COOL - PCA"
+     Workspace   = "production"
+   }
    ```
 
 1. Run the command `terraform init`.
@@ -69,7 +74,9 @@ future changes by simply running `terraform apply
 
 ## Providers ##
 
-No providers.
+| Name | Version |
+|------|---------|
+| aws.organizationsreadonly | ~> 3.38 |
 
 ## Modules ##
 
@@ -79,7 +86,9 @@ No providers.
 
 ## Resources ##
 
-No resources.
+| Name | Type |
+|------|------|
+| [aws_organizations_organization.cool](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/organizations_organization) | data source |
 
 ## Inputs ##
 
@@ -89,7 +98,6 @@ No resources.
 | provisionaccount\_role\_description | The description to associate with the IAM role that allows sufficient permissions to provision all AWS resources in the PCA account. | `string` | `"Allows sufficient permissions to provision all AWS resources in the PCA account."` | no |
 | provisionaccount\_role\_name | The name to assign the IAM role that allows sufficient permissions to provision all AWS resources in the PCA account. | `string` | `"ProvisionAccount"` | no |
 | tags | Tags to apply to all AWS resources created. | `map(string)` | `{}` | no |
-| users\_account\_id | The ID of the users account.  This account will be allowed to assume the role that allows sufficient permissions to provision all AWS resources in the PCA account. | `string` | n/a | yes |
 
 ## Outputs ##
 

--- a/locals.tf
+++ b/locals.tf
@@ -1,0 +1,15 @@
+# Retrieve the information for all accounts in the organization.  This
+# is used, for instance, to lookup the account ID for the Users
+# account.
+data "aws_organizations_organization" "cool" {
+  provider = aws.organizationsreadonly
+}
+
+locals {
+  # Find the Users account
+  users_account_id = [
+    for account in data.aws_organizations_organization.cool.accounts :
+    account.id
+    if account.name == "Users"
+  ][0]
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,8 @@
+output "cw_alarm_sns_topic" {
+  value       = module.cw_alarm_sns.sns_topic
+  description = "The SNS topic to which a message is sent when a CloudWatch alarm is triggered."
+}
+
 output "provisionaccount_role" {
   value       = module.provisionaccount.provisionaccount_role
   description = "The IAM role that allows sufficient permissions to provision all AWS resources in the PCA account."

--- a/providers.tf
+++ b/providers.tf
@@ -12,3 +12,13 @@ provider "aws" {
   # profile = "cool-pca-account-admin"
   region = var.aws_region
 }
+
+# Read-only AWS Organizations provider
+provider "aws" {
+  alias = "organizationsreadonly"
+  default_tags {
+    tags = var.tags
+  }
+  profile = "cool-master-organizationsreadonly"
+  region  = var.aws_region
+}

--- a/provisionaccount.tf
+++ b/provisionaccount.tf
@@ -3,5 +3,5 @@ module "provisionaccount" {
 
   provisionaccount_role_description = var.provisionaccount_role_description
   provisionaccount_role_name        = var.provisionaccount_role_name
-  users_account_id                  = var.users_account_id
+  users_account_id                  = local.users_account_id
 }

--- a/sns.tf
+++ b/sns.tf
@@ -1,0 +1,12 @@
+# ------------------------------------------------------------------------------
+# Create the SNS topic that allows email to be sent for CloudWatch
+# alarms.  Subscribe the account email to the new SNS topic.
+# ------------------------------------------------------------------------------
+
+module "cw_alarm_sns" {
+  providers = {
+    aws                         = aws
+    aws.organizations_read_only = aws.organizationsreadonly
+  }
+  source = "github.com/cisagov/cw-alarm-sns-tf-module"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,15 +1,4 @@
 # ------------------------------------------------------------------------------
-# REQUIRED PARAMETERS
-#
-# You must provide a value for each of these parameters.
-# ------------------------------------------------------------------------------
-
-variable "users_account_id" {
-  type        = string
-  description = "The ID of the users account.  This account will be allowed to assume the role that allows sufficient permissions to provision all AWS resources in the PCA account."
-}
-
-# ------------------------------------------------------------------------------
 # OPTIONAL PARAMETERS
 #
 # These parameters have reasonable defaults.


### PR DESCRIPTION
## 🗣 Description ##

This pull request:
- Makes use of the AWS Organizations read-only provider to obtain the ID of the "Users" AWS account.  Previously the ID of the "Users" account was being passed in as an input parameter.
- Makes use of [cisagov/cw-alarm-sns-tf-module](https://github.com/cisagov/cw-alarm-sns-tf-module) to create an SNS topic that can be published to in order to send a message to the account email when a CloudWatch alarm is triggered.

## 💭 Motivation and context ##

- Passing in the ID of the "Users" account explicitly has been needing to be cleaned up for years.
- We require such an SNS topic so that we can receive emails when CloudWatch alarms indicate a potential problem with the COOL.

## 🧪 Testing ##

All automated testing passes.  This code has already been applied to both the production and staging COOL PCA accounts.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.