### PR TITLE
Use the renamed and generalized cisagov/sns-send-to-account-email-tf-module

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ future changes by simply running `terraform apply
 
 | Name | Source | Version |
 |------|--------|---------|
-| cw\_alarm\_sns | github.com/cisagov/cw-alarm-sns-tf-module | n/a |
+| cw\_alarm\_sns | github.com/cisagov/sns-send-to-account-email-tf-module | n/a |
 | provisionaccount | github.com/cisagov/provisionaccount-role-tf-module | n/a |
 
 ## Resources ##

--- a/sns.tf
+++ b/sns.tf
@@ -8,5 +8,8 @@ module "cw_alarm_sns" {
     aws                         = aws
     aws.organizations_read_only = aws.organizationsreadonly
   }
-  source = "github.com/cisagov/cw-alarm-sns-tf-module"
+  source = "github.com/cisagov/sns-send-to-account-email-tf-module"
+
+  topic_name         = "cloudwatch-alarms"
+  topic_display_name = "cloudwatch_alarms"
 }


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the repo to make use of the renamed and slightly generalized [cisagov/sns-send-to-account-email-tf-module](https://github.com/cisagov/sns-send-to-account-email-tf-module) repo vice the old [cisagov/cw-alarms-sns-tf-module](https://github.com/cisagov/cw-alarms-sns-tf-module) repo.

## 💭 Motivation and context ##

We want to use the same sort of functionality for sending emails when IAM or SSO user accounts are created, so it makes sense to rename and generalize the repo.

See also:
- cisagov/sns-send-to-account-email-tf-module#23
- cisagov/cool-accounts#137
- cisagov/cool-accounts-domain-manager#29

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Post-merge checklist ##

- [x] Ensure that these changes are applied to both Staging and Production.